### PR TITLE
Upgrade composer.json for passport 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Transforms Laravel Passport's default incrementing integer client_id into an industry standard unique hashed string. Optionally, you can use encrypted client secrets for improved security. The package is non-intrusive. See the readme for details.",
     "type": "library",
     "require": {
-        "laravel/passport": "^5.0",
+        "laravel/passport": "^6.0",
         "vinkla/hashids": "^5.0",
         "doctrine/dbal": "^2.6"
     },


### PR DESCRIPTION
Little change of passport version.
I have not hard try with passport 6.0, but i don't think this can break : Change from 5.0 -> 6.0 its configuration of private/public key and the oauth2 PHP league server upgrade
https://github.com/laravel/passport/compare/6.0
(And thanks for this solution to bypass the simple increment id :smiley:)