### PR TITLE
Add hashed_passport middleware to existing route

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -1,4 +1,3 @@
 <?php
 
-Route::post('oauth/token', '\Laravel\Passport\Http\Controllers\AccessTokenController@issueToken')
-    ->middleware(['throttle', 'hashed_passport']);
+Route::getRoutes()->getByName('passport.token')->middleware('hashed_passport');


### PR DESCRIPTION
Add the 'hashed_passport'-middleware to the registered passport route instead of redefining the entire route.