### PR TITLE
Fix authorization_code grant.

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -2,3 +2,4 @@
 
 Route::post('oauth/token', '\Laravel\Passport\Http\Controllers\AccessTokenController@issueToken')
     ->middleware(['throttle', 'hashed_passport']);
+Route::getRoutes()->getByName('passport.authorizations.authorize')->middleware('hashed_passport');


### PR DESCRIPTION
Add the 'hashed_passport'-middleware to the 'passport.authorizations.authorize'-route.